### PR TITLE
Improve character encoding configuration

### DIFF
--- a/BinaryPlist.py
+++ b/BinaryPlist.py
@@ -81,7 +81,6 @@ class BinaryPlistToggleCommand(TextCommand):
       with open(file_name, 'rb') as fp:
         pl = plistlib.load(fp)
       full_text = plistlib.dumps(pl).decode('utf-8')
-      view.set_encoding('UTF-8')
       # print("view.size()={0}".format(view.size()))
       view.replace(edit, Region(0, view.size()), full_text)
       view.end_edit(edit)
@@ -103,9 +102,12 @@ class BinaryPlistToggleCommand(TextCommand):
         raise e
 
   def run(self, edit, force_to=False):
-    if is_binary_plist(self.view) and not force_to:
-      self.to_xml_plist(edit, self.view)
-      if not is_syntax_set(self.view):
-        self.view.set_syntax_file(SYNTAX_FILE)
+    if self.view.encoding() == 'UTF-8':
+      if is_binary_plist(self.view) and not force_to:
+        self.to_xml_plist(edit, self.view)
+        if not is_syntax_set(self.view):
+          self.view.set_syntax_file(SYNTAX_FILE)
+      else:
+        self.to_binary_plist(self.view)
     else:
-      self.to_binary_plist(self.view)
+      self.view.set_encoding('UTF-8')


### PR DESCRIPTION
This prevents the view from reloading by setting the character encoding only once.