### PR TITLE
Fix invalid characters

### DIFF
--- a/BinaryPlist.py
+++ b/BinaryPlist.py
@@ -82,6 +82,8 @@ class BinaryPlistToggleCommand(TextCommand):
         pl = plistlib.load(fp)
       full_text = plistlib.dumps(pl).decode('utf-8')
       view.set_encoding('UTF-8')
+      if "�" in full_text:
+        sublime.message_dialog("This file contains “�” characters, likely due to control characters in strings.\n\nIf you save the file, these replacement characters will remain.")
       # print("view.size()={0}".format(view.size()))
       view.replace(edit, Region(0, view.size()), full_text)
       view.end_edit(edit)

--- a/plistlib/plistlib.py
+++ b/plistlib/plistlib.py
@@ -295,10 +295,7 @@ def _date_to_string(d):
     )
 
 def _escape(text):
-    m = _controlCharPat.search(text)
-    if m is not None:
-        raise ValueError("strings can't contains control characters; "
-                         "use bytes instead")
+    text = _controlCharPat.sub("�", text)
     text = text.replace("\r\n", "\n")       # convert DOS line endings
     text = text.replace("\r", "\n")         # convert Mac line endings
     text = text.replace("&", "&amp;")       # escape '&'


### PR DESCRIPTION
This prevents files containing invalid characters, such as control codes in strings, from being displayed. These characters are valid for binary property list files.